### PR TITLE
Add cache for tester

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _site/
+_includes/source_code/cache.csv
 _includes/source_code/testdata/
 _includes/source_code/test_parser.out
 _includes/source_code/tmp/

--- a/_includes/source_code/MakeFile
+++ b/_includes/source_code/MakeFile
@@ -1,0 +1,2 @@
+test_parser.out: utils/test_parser.cc
+	g++ --std=c++17 -fexceptions -O2 -o test_parser.out utils/test_parser.cc -lstdc++fs

--- a/_includes/source_code/tester.sh
+++ b/_includes/source_code/tester.sh
@@ -1,3 +1,4 @@
-g++ --std=c++17 -fexceptions -o test_parser.out utils/test_parser.cc -lstdc++fs && ./test_parser.out $1
+make
+./test_parser.out $1
 sed -i 's/\r//' generated_execution.sh
 bash generated_execution.sh

--- a/_includes/source_code/utils/test_parser.cc
+++ b/_includes/source_code/utils/test_parser.cc
@@ -721,7 +721,11 @@ std::vector<Task*> getTasksFor(std::string& task_name) {
       }
       cache_in.close();
       if (!path.empty()) {
-         return getAllTaskNodes({ path + "/TASK" }, false);
+         std::vector<Task*> ans = getAllTaskNodes({ path + "/TASK" }, false);
+			// Verify that the task name has not changed.
+			if (ans[0]->name == task_name) {
+				return ans;
+			}
       }
    }
    


### PR DESCRIPTION
Κάθε φορά που είναι να ελεγχθεί ένα πρόγραμμα, ο tester ψάχνει όλους τους φακέλους για να βρει αυτόν με το σωστό TASK name. Αυτό είναι σχετικά χρονοβόρο. Σε αυτή την αλλαγή ο tester δημιουργεί ένα αρχείο (cache.csv) με (task_names, paths) ώστε  να βρίσκει γρήγορα το path του αρχείου TASK.

Επίσης, κάθε φορά που έτρεχε κάποιος τον tester, κάνει recompile τον test_parser. Σε αυτή την αλλαγή μπαίνει ένα απλό Makefile για να αποφευχθούν τα recompilations όταν δεν χρειάζονται.